### PR TITLE
[TEQ-37] Finish galaxy role checking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ bootstrap
 
 Does the simplest possible install of Python v2 so that Ansible can
 run from then on.
+
 Use when the target servers might not even have Python installed.::
 
     $ fab <ENVNAME> bootstrap
@@ -104,7 +105,10 @@ check_role_versions
 ...................
 
 Check that the roles required in requirements.yml are all installed
-and at the right version, and fail if not.
+and at the right version. If any are not installed, install them.
+If any are installed from Galaxy but at the wrong version, fail. If
+any are installed locally rather than from Galaxy, fail, unless the
+dev flag is set (see the `dev` task).
 
 This gets run automatically before a deploy or bootstrap, so won't
 often need to be run by itself.::
@@ -153,6 +157,11 @@ Some examples::
     $ fab staging deploy:playbook=site
     $ fab staging deploy:branch=PRJ-9999
     $ fab staging deploy:playbook=site:extra_vars=gunicorn_num_workers=8
+
+dev
+...
+
+Turn on 'dev' flag which can change the behavior of other tasks.
 
 install_roles
 .............

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,13 @@
 Releases
 ========
 
+* next
+
+  * If a required role is not installed, check_installed_roles installs it.
+  * New task 'dev' sets a 'dev' flag that can affect behavior of other tasks.
+  * If a role is installed locally instead of from Galaxy, check_installed_roles
+    fails unless the 'dev' flag is set.
+
 * 0.0.2, 2019-01-17
 
   * Add Python 2.7 support.

--- a/tequila_fab/__init__.py
+++ b/tequila_fab/__init__.py
@@ -15,6 +15,11 @@ from fabric.tasks import execute
 from .ansible import check_role_versions, install_roles
 
 #
+# Initialize env flags
+#
+env.devflag = False
+
+#
 # KEEP TASKS IN ALPHABETICAL ORDER
 #
 __ALL__ = [
@@ -37,7 +42,7 @@ def bootstrap():
     install_roles()
     execute(check_role_versions)
     deploy("bootstrap_python")
-    deploy("site", extra_vars='{"unmanaged_users": [ubuntu]}')
+    deploy("site")
 
 
 @task
@@ -70,3 +75,12 @@ def deploy(play=None, extra_vars=None, branch=None):
     cmd.append("-e ansible_working_directory=%s" % os.getcwd())
     local(" ".join(cmd))
 
+
+@task
+def dev():
+    """
+    Usage: fab dev <other commands>
+
+    Turns on 'dev' flag which may change behavior of other commands.
+    """
+    env.devflag = True

--- a/tequila_fab/ansible.py
+++ b/tequila_fab/ansible.py
@@ -6,7 +6,7 @@ import os.path
 # FIXME: when we drop Python 2 support, change the comment-style type annotations to Python 3 style.
 
 import yaml
-from fabric.api import local
+from fabric.api import env, local
 from fabric.colors import red, green, yellow
 from fabric.decorators import task
 from fabric.tasks import execute

--- a/tequila_fab/ansible.py
+++ b/tequila_fab/ansible.py
@@ -2,7 +2,6 @@ import configparser
 import functools
 import os
 import os.path
-import sys
 
 # FIXME: when we drop Python 2 support, change the comment-style type annotations to Python 3 style.
 
@@ -10,6 +9,8 @@ import yaml
 from fabric.api import local
 from fabric.colors import red, green, yellow
 from fabric.decorators import task
+from fabric.tasks import execute
+from fabric.utils import abort
 
 
 @functools.lru_cache(maxsize=1)
@@ -89,20 +90,27 @@ def check_role_versions():  # type: () -> None
     """
     Usage: fab check_role_versions
 
-    Fails if the exact versions of roles specified in deployment/requirements.yml
-    are not installed.
+    If the wrong versions of any roles are installed, per deployment/requirements.yml,
+    fail.
+
+    If any required roles are not installed, install them.
+
+    If env.devflag is true, warns but ignores any locally installed roles. Otherwise,
+    locally installed roles are a fatal error. See the `dev` task
+    to set env.devflag.
     """
 
     okay = True  # False if we've spotted any problems
     bad = []  # Paths to where missing roles should be installed, or where bad version roles are installed
     requirements = yaml.load(open("deployment/requirements.yml"))
     requirements = sorted(requirements, key=req_name)
+    requirements_to_install = False
     for req in requirements:
         name = req_name(req)
         install_dir = find_install_role(name)
         if not install_dir:
-            okay = False
-            print(red("ERROR: role %s not installed" % (name,)))
+            print(yellow("WARNING: role %s not installed" % (name,)))
+            requirements_to_install = True
             continue
         meta_path = os.path.join(install_dir, 'meta/.galaxy_install_info')
         if os.path.exists(meta_path):
@@ -120,11 +128,20 @@ def check_role_versions():  # type: () -> None
                 print(green("GOOD:  role %s %s at %s" % (name, meta['version'], install_dir)))
         else:
             # User must have installed this locally, don't check version
-            print(yellow("SKIP:  role %s at %s appears to have been locally installed" % (name, install_dir)))
+            if env.devflag:
+                print(yellow("SKIP:  role %s at %s appears to have been locally installed" % (name, install_dir)))
+            else:
+                okay = False
+                print(red("ERROR:  role %s at %s appears to have been locally installed, will not continue" % (name, install_dir)))
+                print(red("To ignore this error, add 'dev' argument to fab command before this"))
+
+    if requirements_to_install and okay:
+        execute(install_roles)
+
     if not okay:
         print(red("Ansible galaxy role requirements are not satisfied, quitting.  The simplest fix is to delete "
                   "the roles that have wrong versions, then run ``fab install_roles`` again."))
         if bad:
             print("E.g.")
             print("$ rm -r %s" % " ".join(badname for badname in bad))
-        sys.exit(1)
+        abort('check_installed_roles failed')


### PR DESCRIPTION
  * If a required role is not installed, check_installed_roles installs it.
  * New task 'dev' sets a 'dev' flag that can affect behavior of other tasks.
  * If a role is installed locally instead of from Galaxy, check_installed_roles
    fails unless the 'dev' flag is set.

This finishes the AC from https://caktus.atlassian.net/browse/TEQ-37