### PR TITLE
Undo change that shouldn't have been in last release

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+* next
+
+  * Undo change to how unmanaged users are set on bootstrap deploy that
+    shouldn't have been in the last release.
+
 * 0.0.3, 2019-04-23
 
   * If a required role is not installed, check_installed_roles installs it.

--- a/tequila_fab/__init__.py
+++ b/tequila_fab/__init__.py
@@ -42,7 +42,7 @@ def bootstrap():
     install_roles()
     execute(check_role_versions)
     deploy("bootstrap_python")
-    deploy("site")
+    deploy("site", extra_vars='{"unmanaged_users": [ubuntu]}')
 
 
 @task


### PR DESCRIPTION
Affects how unmanaged users are set during a bootstrap deploy.