### PR TITLE
[TEQ-86] Add task to allow virtualenv to be recreated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,16 +147,17 @@ name.
    *web* playbook, which just updates the web servers.
 
 You can also set/override any Ansible variable by passing
-the ``extra_vars`` option.  Here's the usage::
+the ``extra_vars`` option (`Provided you carefully quote things
+<https://github.com/fabric/fabric/issues/1306>`_).  Here's the usage::
 
-    $ fab <ENV> deploy[:playbook=NNNN][:extra_vars=aaa=1,bbb=2][:branch=xxx]
+    $ fab <ENV> deploy[:playbook=NNNN][:extra_vars="aaa\=1,bbb\=2"][:branch=xxx]
 
 Some examples::
 
     $ fab staging deploy
     $ fab staging deploy:playbook=site
     $ fab staging deploy:branch=PRJ-9999
-    $ fab staging deploy:playbook=site:extra_vars=gunicorn_num_workers=8
+    $ fab staging deploy:playbook=site:extra_vars="gunicorn_num_workers\=8"
 
 dev
 ...
@@ -188,3 +189,14 @@ Run Ansible galaxy's role installer for the requirements in
     on your roles_path by default. Maybe install_roles ought to
     override that on the command line and always install to
     deployment/roles?
+
+recreate_venv
+.............
+
+Force ansible to delete the virtualenv directory so that it gets
+recreated. This allows us to upgrade the Python binary in the
+virtualenv.
+
+.. note::
+
+   This also does a deploy of the ``web`` role.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+* 0.0.6, 2019-08-06
+
+  * New task 'recreate_venv' allows virtualenv to be recreated. Requires
+    tequila-django >= 0.9.24.
+
 * 0.0.5, 2019-06-17
 
   * Fix version number in setup.py.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='tequila-fab',
-    version='0.0.5',
+    version='0.0.6',
     packages=[
         'tequila_fab',
     ],

--- a/tequila_fab/__init__.py
+++ b/tequila_fab/__init__.py
@@ -84,3 +84,16 @@ def dev():
     Turns on 'dev' flag which may change behavior of other commands.
     """
     env.devflag = True
+
+
+@task
+def recreate_venv():
+    """
+    Usage: <ENV> fab recreate_venv
+
+    Forces the virtualenv to be deleted and then deploys the web tasks
+    so that a new virtualenv is created with a refreshed copy of the
+    Python binary.
+    """
+    require('environment')
+    deploy('web', extra_vars={'force_recreate_venv': True})


### PR DESCRIPTION
This takes advantage of the new variable that will be in tequila-django 0.9.24 to make it easier for
devs to refresh the virtualenv.

https://caktus.atlassian.net/browse/TEQ-86