### PR TITLE
Release 0.0.7: Add a new "limit" option to the "deploy" task to pass a --limit through to ansible-playbook.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,8 @@ name.
 
 You can also set/override any Ansible variable by passing
 the ``extra_vars`` option (`Provided you carefully quote things
-<https://github.com/fabric/fabric/issues/1306>`_).  Here's the usage::
+<https://github.com/fabric/fabric/issues/1306>`_) and/or pass through
+an argument to ``ansible-playbook``'s ``--limit`` option.  Here's the usage::
 
     $ fab <ENV> deploy[:playbook=NNNN][:extra_vars="aaa\=1,bbb\=2"][:branch=xxx]
 
@@ -158,6 +159,7 @@ Some examples::
     $ fab staging deploy:playbook=site
     $ fab staging deploy:branch=PRJ-9999
     $ fab staging deploy:playbook=site:extra_vars="gunicorn_num_workers\=8"
+    $ fab staging deploy:limit=bastion
 
 dev
 ...

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+* 0.0.7, 2019-09-06
+
+  * Add a new "limit" option to the deploy task to pass a "--limit" through
+    to ansible-playbook.
+
 * 0.0.6, 2019-08-06
 
   * New task 'recreate_venv' allows virtualenv to be recreated. Requires

--- a/tequila_fab/__init__.py
+++ b/tequila_fab/__init__.py
@@ -58,7 +58,7 @@ def create_superuser(email):
 
 
 @task
-def deploy(play=None, extra_vars=None, branch=None):
+def deploy(play=None, extra_vars=None, branch=None, limit=None):
     """
     Usage: fab <ENV> deploy[:playbook=NNNN][:extra_vars=aaa=1,bbb=2][:branch=xxx]
     """
@@ -72,6 +72,8 @@ def deploy(play=None, extra_vars=None, branch=None):
         cmd.append("--extra-vars='{extra_vars}'".format(extra_vars=extra_vars))
     if branch:
         cmd.append("-e repo_branch=%s" % branch)
+    if limit:
+        cmd.append("-l %s" % limit)
     cmd.append("-e ansible_working_directory=%s" % os.getcwd())
     local(" ".join(cmd))
 


### PR DESCRIPTION
For hosts that need to be provisioned first (like a bastion instance), we need a way to run a deploy only on a specific host (since we want the "common" plays to run, just not on all hosts). This might be useful for other purposes, too.